### PR TITLE
Share-link resolution: a pure layer that turns a pasted share URL into a direct-download URL (or an honest refusal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,11 +417,32 @@ are being downloaded from the internet. The typical function would be:
 key_ingress = lambda key: print(f"Getting {key} from the internet")
 ```
 
-## Does graze work for dropbox links?
+## Does graze work for dropbox (and drive, and onedrive) share links?
 
-Yes it does, but you need to be aware that dropbox systematically send the data as a zip, **even if there's only one file in it**.
+A *share link* is what you copy out of Dropbox or Google Drive. It is **not** a
+download URL — fetching it usually gets you an HTML preview page. `graze.share_links`
+turns one into a description of what it actually denotes, with no network access at all:
 
-Here's some code that can help.
+```python
+from graze import resolve_share_url, direct_download_url
+
+r = resolve_share_url('https://www.dropbox.com/scl/fo/q7x/AAB?rlkey=zz&dl=0')
+r.provider    # 'dropbox'
+r.kind        # <ShareLinkKind.ARCHIVE: 'archive'>  -- a folder, i.e. a ZIP
+r.direct_url  # '...?rlkey=zz&dl=1'  (dl=1 forced; every other param kept verbatim)
+```
+
+`dl=1` is forced because `dl=0` is **User-Agent dependent** — the same folder link
+served a 31 KB zip to one client and 224 KB of HTML to another. Normalizing is a
+correctness requirement, not a nicety.
+
+`graze` uses this automatically: a Dropbox link is resolved before it is fetched.
+
+Two things worth knowing:
+
+**A folder link is a ZIP** — dropbox sends the data as an archive, **even if there's
+only one file in it** — so `kind == 'archive'` means "expand me", not "here's your
+asset":
 
 ```python
 def zip_store_of_dropbox_url(dropbox_url: str):
@@ -439,6 +460,32 @@ def filebytes_of_dropbox_url(dropbox_url: str, assert_only_one_file=True):
     if assert_only_one_file:
         assert next(zip_filepaths, None) is None, f"More than one file in {dropbox_url}"
     return zip_store[first_filepath]
+```
+
+**Some links have no download URL at all, and graze says so** rather than guessing —
+a Google Drive *folder* needs the Drive API, a Google Workspace document has to be
+exported (in a format only you can choose), and OneDrive's contract hasn't been
+measured yet. Those raise `ShareLinkResolutionError`, carrying the reason:
+
+```python
+direct_download_url('https://drive.google.com/drive/folders/1AbCdEf')
+# ShareLinkResolutionError: Cannot resolve this google_drive link ... enumerating a
+# folder needs the Drive API (files.list with q="'1AbCdEf' in parents") and a credential.
+```
+
+Adding a provider takes no core edits — register an adapter:
+
+```python
+from graze import add_share_link_resolver, ResolvedShareLink, ShareLinkKind
+
+def resolve_my_host(url):
+    if url.startswith('https://my.host/dl/'):
+        return ResolvedShareLink(
+            url=url, provider='my_host', kind=ShareLinkKind.FILE, direct_url=url + '?raw=1'
+        )
+    # returning None means "not mine" -- the next adapter gets a turn
+
+add_share_link_resolver('my_host', resolve_my_host)
 ```
 
 ## How do I use tiny_url?

--- a/graze/__init__.py
+++ b/graze/__init__.py
@@ -15,6 +15,15 @@ from graze.base import (
     key_egress_print_downloading_message,
 )
 from graze.util import handle_missing_dir, tiny_url
+from graze.share_links import (
+    ShareLinkKind,
+    ResolvedShareLink,
+    ShareLinkResolutionError,
+    resolve_share_url,
+    direct_download_url,
+    share_link_resolvers,
+    add_share_link_resolver,
+)
 from graze.graze_exceptional import (
     graze_cache,
     add_exception,

--- a/graze/base.py
+++ b/graze/base.py
@@ -523,8 +523,9 @@ def url_to_file_download(
             the data if the file hasn't been modified for X days (i.e. stale contents).
         url_egress: The function to call on the url before getting the contents from it.
             This can, for example, be used to notify the user that data is being
-            downloaded, or to modify the url before fetching the contents (for example,
-            replacing the dl=0 in a dropbox url with dl=1).
+            downloaded, or to modify the url before fetching the contents.
+            Note you do NOT need it to normalize share links: `graze.share_links`
+            already resolves those (Dropbox's `dl=1` among them) on the way in.
         rootdir: The root directory where the file will be stored
         ensure_dirs: Whether to ensure the directories of the file exist
         read_contents_of_file: The function to read the contents of a file
@@ -540,8 +541,10 @@ def url_to_file_download(
     process.
 
     Need to decide how to download the url based on some characteristics of the url?
-    For example, if it's a dropbox url with dl=0, change that to dl=1.
-    Put this in the url_to_contents logic.
+    Put this in the url_to_contents logic -- or, for a *provider* rule (this is a
+    Dropbox folder link, so it needs dl=1 and comes back as a ZIP), register an
+    adapter with `graze.add_share_link_resolver` and let `special_url_routes`
+    dispatch to it.
 
     """
     if filepath is None:

--- a/graze/share_links.py
+++ b/graze/share_links.py
@@ -1,0 +1,602 @@
+"""Pure (network-free) resolution of cloud share links to direct-download URLs.
+
+A *share link* is what a person copies out of Dropbox / Google Drive / OneDrive.
+It is **not** a download URL: fetching it usually gets you an HTML preview page,
+and — worse — what you get can depend on your ``User-Agent`` rather than on the
+link. This module maps a pasted share link to a description of what it actually
+denotes::
+
+    share link  ->  ResolvedShareLink(provider, kind, direct_url, reason)
+
+Everything here is a ``str -> description`` mapping. **No function in this module
+opens a socket**, which is the whole point: resolution is deterministic and
+testable offline, while fetching (redirect policy, byte caps, content-type
+assertions, SSRF protection) is a separate concern that belongs to the transport
+layer, and archive expansion (a folder link is a ZIP, see :class:`ShareLinkKind`)
+belongs to the caller.
+
+The two things a caller needs to know before fetching:
+
+- **the direct URL** — or, honestly, that there isn't one (some links genuinely
+  need a provider API, and this module refuses rather than guess);
+- **the kind** — a *file* and a *folder* are different operations. A Dropbox
+  folder link downloads as a single ZIP that must be expanded into N assets.
+
+Simple use — give me something I can fetch, or tell me why not:
+
+>>> direct_download_url('https://www.dropbox.com/scl/fi/a1b2/clip.mp4?rlkey=zz&dl=0')
+'https://www.dropbox.com/scl/fi/a1b2/clip.mp4?rlkey=zz&dl=1'
+
+>>> direct_download_url('https://drive.google.com/drive/folders/1AbCdEf')
+Traceback (most recent call last):
+    ...
+graze.share_links.ShareLinkResolutionError: Cannot resolve this google_drive link...
+
+Full use — the whole description, including what kind of thing it is:
+
+>>> r = resolve_share_url('https://www.dropbox.com/scl/fo/x9/y?rlkey=zz&dl=0')
+>>> r.provider, r.kind.value, r.resolved
+('dropbox', 'archive', True)
+>>> r.direct_url
+'https://www.dropbox.com/scl/fo/x9/y?rlkey=zz&dl=1'
+
+``kind == 'archive'`` is the signal that the bytes are a ZIP of many members,
+not one asset -- ``dol.FilesOfZip`` is the tool for that half.
+
+A URL that is nobody's share link passes through unchanged:
+
+>>> r = resolve_share_url('https://example.com/video.mp4')
+>>> r.provider, r.direct_url
+('http', 'https://example.com/video.mp4')
+
+Adding a provider is open-closed -- register an adapter, no core edits:
+
+>>> def resolve_my_host(url):
+...     if url.startswith('https://my.host/dl/'):
+...         return ResolvedShareLink(
+...             url=url, provider='my_host', kind=ShareLinkKind.FILE,
+...             direct_url=url + '?raw=1',
+...         )
+>>> add_share_link_resolver('my_host', resolve_my_host)
+>>> resolve_share_url('https://my.host/dl/thing').direct_url
+'https://my.host/dl/thing?raw=1'
+>>> del share_link_resolvers['my_host']  # (cleaning up after the example)
+
+Note: this module is **not** a security boundary. It will happily hand back a URL
+pointing anywhere; validating scheme/port/address and re-validating every redirect
+hop is the transport layer's job.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Optional
+from urllib.parse import urlsplit, urlunsplit, unquote
+
+
+# --------------------------------------------------------------------------------------
+# The vocabulary
+
+
+class ShareLinkKind(str, Enum):
+    """What a share link denotes -- a file, an archive, a folder, or unknown.
+
+    ``ARCHIVE`` is a refinement of ``FILE``: the URL still resolves to one blob,
+    but that blob is a ZIP the caller must expand into N assets. Providers render
+    *folder* links this way (Dropbox does so even for a single-file folder).
+
+    ``FOLDER`` is the honest answer when a link denotes a folder and the provider
+    offers **no** URL that downloads it -- listing it needs an API credential.
+
+    >>> ShareLinkKind.ARCHIVE.value
+    'archive'
+    >>> ShareLinkKind('folder') is ShareLinkKind.FOLDER
+    True
+    """
+
+    FILE = "file"
+    ARCHIVE = "archive"
+    FOLDER = "folder"
+    UNKNOWN = "unknown"
+
+    def __str__(self) -> str:
+        # Keeps str()/format() equal to the value on every Python version
+        # (bare `str, Enum` mixins changed __format__ behaviour in 3.11).
+        return self.value
+
+
+class ShareLinkResolutionError(ValueError):
+    """Raised when a share link cannot be resolved to a direct-download URL."""
+
+
+@dataclass(frozen=True)
+class ResolvedShareLink:
+    """What a share URL denotes, and how (or whether) to fetch it.
+
+    Args:
+        url: The share URL as given (stripped of surrounding whitespace).
+        provider: Provider slug, e.g. ``'dropbox'``, ``'google_drive'``,
+            ``'onedrive'``, ``'http'`` (a plain URL that is nobody's share link),
+            or ``'unknown'``.
+        kind: See :class:`ShareLinkKind`.
+        direct_url: A URL whose response body is the content -- or ``None`` when
+            the link cannot be resolved without a provider API.
+        reason: Why ``direct_url`` is ``None``. Required whenever it is.
+
+    ``direct_url`` and ``kind`` are independent: a Google Workspace document is a
+    ``FILE`` that still has no resolvable download URL.
+
+    >>> r = ResolvedShareLink('https://x/y', 'http', ShareLinkKind.FILE, 'https://x/y')
+    >>> r.resolved
+    True
+
+    An unresolved link must say why -- an adapter that refuses silently is a bug:
+
+    >>> ResolvedShareLink('https://x/y', 'nope', ShareLinkKind.UNKNOWN)
+    Traceback (most recent call last):
+        ...
+    ValueError: An unresolved ResolvedShareLink must carry a reason (url: https://x/y)
+    """
+
+    url: str
+    provider: str
+    kind: ShareLinkKind
+    direct_url: Optional[str] = None
+    reason: Optional[str] = None
+
+    def __post_init__(self):
+        if self.direct_url is None and not self.reason:
+            raise ValueError(
+                f"An unresolved ResolvedShareLink must carry a reason (url: {self.url})"
+            )
+
+    @property
+    def resolved(self) -> bool:
+        """True when there is a direct URL to fetch."""
+        return self.direct_url is not None
+
+
+#: An adapter: given a URL, return its resolution, or ``None`` for "not mine".
+ShareLinkResolver = Callable[[str], Optional[ResolvedShareLink]]
+
+
+# --------------------------------------------------------------------------------------
+# URL string surgery (verbatim-preserving: share links carry bearer secrets)
+
+
+def _force_query_param(url: str, key: str, value: str) -> str:
+    """Set query param ``key`` to ``value``, leaving every other byte untouched.
+
+    Deliberately does *not* round-trip through ``parse_qsl``/``urlencode``: share
+    links carry credentials in the query (Dropbox's ``rlkey``, Drive's
+    ``resourcekey``) and re-encoding them is a needless way to corrupt one.
+
+    >>> _force_query_param('https://x.com/a?rlkey=Z_-9&dl=0', 'dl', '1')
+    'https://x.com/a?rlkey=Z_-9&dl=1'
+    >>> _force_query_param('https://x.com/a', 'dl', '1')
+    'https://x.com/a?dl=1'
+    >>> _force_query_param('https://x.com/a?dl=0&st=q&dl=0#frag', 'dl', '1')
+    'https://x.com/a?st=q&dl=1#frag'
+    """
+    parts = urlsplit(url)
+    kept = [
+        component
+        for component in parts.query.split("&")
+        if component and component.split("=", 1)[0] != key
+    ]
+    kept.append(f"{key}={value}")
+    return urlunsplit(parts._replace(query="&".join(kept)))
+
+
+def _query_value(query: str, key: str) -> Optional[str]:
+    """First value of ``key`` in a raw query string, percent-decoded, else None.
+
+    >>> _query_value('export=download&id=1A-b_C', 'id')
+    '1A-b_C'
+    >>> _query_value('export=download', 'id') is None
+    True
+    """
+    for component in query.split("&"):
+        name, _, value = component.partition("=")
+        if name == key:
+            return unquote(value)
+    return None
+
+
+def _host_of(url: str) -> str:
+    """Lower-cased host of a URL, without port or userinfo.
+
+    Parsing the host is what stops a substring match from being spoofable:
+    ``https://evil.example/?u=drive.google.com/file/d/x`` is not a Drive link.
+
+    >>> _host_of('https://Drive.Google.com:443/file/d/x')
+    'drive.google.com'
+    >>> _host_of('https://evil.example/?u=drive.google.com/file/d/x')
+    'evil.example'
+    """
+    return (urlsplit(url).hostname or "").lower()
+
+
+# --------------------------------------------------------------------------------------
+# Dropbox
+#
+# Measured (2026-08-06, live links): www.dropbox.com answers every share link with a
+# 302 to a *.dl.dropboxusercontent.com host; a FOLDER link's final response is
+# `content-type: application/zip` + `content-disposition: attachment;
+# filename="<folder>.zip"` + magic PK\x03\x04 -- i.e. an archive, not a listing.
+# And `dl=0` is User-Agent dependent (a wget UA got the zip; a browser UA got 224 KB
+# of HTML), while `dl=1` returned the archive for every client tested. Forcing dl=1
+# is therefore a *correctness* requirement, not a convenience.
+
+DROPBOX_HOSTS = ("www.dropbox.com", "dropbox.com")
+
+#: Share-link path prefixes -> what they denote. ``/s/`` + ``/sh/`` are the legacy
+#: forms; ``/scl/fi/`` + ``/scl/fo/`` are the ones Dropbox issues today.
+DROPBOX_PATH_KINDS = (
+    ("/scl/fi/", ShareLinkKind.FILE),
+    ("/scl/fo/", ShareLinkKind.ARCHIVE),
+    ("/s/", ShareLinkKind.FILE),
+    ("/sh/", ShareLinkKind.ARCHIVE),
+)
+
+_DROPBOX_SHARE_NAMESPACES = ("/scl/", "/s/", "/sh/")
+
+
+def resolve_dropbox(url: str) -> Optional[ResolvedShareLink]:
+    """Resolve a Dropbox share link by forcing ``dl=1``.
+
+    Both the modern ``/scl/`` forms and the legacy ``/s/`` + ``/sh/`` forms; every
+    other query parameter (notably ``rlkey``, which is a bearer secret) is kept
+    byte-for-byte.
+
+    >>> r = resolve_dropbox('https://www.dropbox.com/s/a1/data.csv?dl=0')
+    >>> r.kind.value, r.direct_url
+    ('file', 'https://www.dropbox.com/s/a1/data.csv?dl=1')
+
+    A folder link is an *archive* -- one ZIP holding N members:
+
+    >>> r = resolve_dropbox('https://www.dropbox.com/scl/fo/q7/z?rlkey=abc&st=t1')
+    >>> r.kind.value, r.direct_url
+    ('archive', 'https://www.dropbox.com/scl/fo/q7/z?rlkey=abc&st=t1&dl=1')
+
+    Non-share Dropbox URLs are not this adapter's business:
+
+    >>> resolve_dropbox('https://www.dropbox.com/home') is None
+    True
+    >>> resolve_dropbox('https://example.com/s/a1/data.csv?dl=0') is None
+    True
+    """
+    if _host_of(url) not in DROPBOX_HOSTS:
+        return None
+    path = urlsplit(url).path
+    for prefix, kind in DROPBOX_PATH_KINDS:
+        if path.startswith(prefix):
+            return ResolvedShareLink(
+                url=url,
+                provider="dropbox",
+                kind=kind,
+                direct_url=_force_query_param(url, "dl", "1"),
+            )
+    if any(path.startswith(namespace) for namespace in _DROPBOX_SHARE_NAMESPACES):
+        return ResolvedShareLink(
+            url=url,
+            provider="dropbox",
+            kind=ShareLinkKind.UNKNOWN,
+            reason=(
+                "Unrecognised Dropbox share-link form. graze knows /scl/fi/ and /s/ "
+                "(file) and /scl/fo/ and /sh/ (folder, downloads as a ZIP); this path "
+                f"is {path!r}. Measure what the link serves, then register an adapter "
+                "with add_share_link_resolver."
+            ),
+        )
+    return None
+
+
+# --------------------------------------------------------------------------------------
+# Google Drive
+
+GOOGLE_DRIVE_HOSTS = ("drive.google.com", "drive.usercontent.google.com")
+GOOGLE_WORKSPACE_HOST = "docs.google.com"
+
+_gdrive_file_path_re = re.compile(r"^/file/d/([\w-]+)")
+_gdrive_folder_path_re = re.compile(r"^/drive/(?:u/\d+/)?folders/([\w-]+)")
+_gworkspace_app_re = re.compile(r"^/(document|spreadsheets|presentation|forms)/d/")
+
+#: Paths that are already direct-download endpoints -- pass them through untouched
+#: rather than rebuild them, so any extra parameters they carry survive.
+_GDRIVE_DIRECT_PATHS = {
+    "drive.google.com": ("/uc",),
+    "drive.usercontent.google.com": ("/download",),
+}
+
+
+def _google_drive_file_url(file_id: str, *, resource_key: Optional[str] = None) -> str:
+    """Build Drive's direct-download URL for a file id.
+
+    >>> _google_drive_file_url('1AbC')
+    'https://drive.google.com/uc?export=download&id=1AbC'
+    >>> _google_drive_file_url('1AbC', resource_key='0-xy')
+    'https://drive.google.com/uc?export=download&id=1AbC&resourcekey=0-xy'
+    """
+    url = f"https://drive.google.com/uc?export=download&id={file_id}"
+    if resource_key:
+        url += f"&resourcekey={resource_key}"
+    return url
+
+
+def resolve_google_drive(url: str) -> Optional[ResolvedShareLink]:
+    """Resolve a Google Drive / Google Workspace URL.
+
+    Files resolve; **folders and Workspace documents are refused**, because
+    neither has a plain-URL download and pretending otherwise is how a folder id
+    ends up in a file-download URL.
+
+    >>> resolve_google_drive('https://drive.google.com/file/d/1AbC/view').direct_url
+    'https://drive.google.com/uc?export=download&id=1AbC'
+
+    A ``resourcekey`` (required by link-shared files created before 2021) is kept:
+
+    >>> r = resolve_google_drive('https://drive.google.com/file/d/1AbC/view?resourcekey=0-x')
+    >>> r.direct_url
+    'https://drive.google.com/uc?export=download&id=1AbC&resourcekey=0-x'
+
+    A folder is a folder -- refused, with the reason and the id to hand:
+
+    >>> r = resolve_google_drive('https://drive.google.com/drive/folders/1FoLd')
+    >>> r.kind.value, r.direct_url is None
+    ('folder', True)
+    >>> print(r.reason)  # doctest: +ELLIPSIS
+    Google Drive folder links have no direct-download URL...
+
+    So is a native Google doc -- a file, but not a downloadable one:
+
+    >>> r = resolve_google_drive('https://docs.google.com/spreadsheets/d/1Sh/edit')
+    >>> r.kind.value, r.direct_url is None
+    ('file', True)
+
+    >>> resolve_google_drive('https://example.com/file/d/1AbC/view') is None
+    True
+    """
+    host = _host_of(url)
+    parts = urlsplit(url)
+
+    if host == GOOGLE_WORKSPACE_HOST:
+        app_match = _gworkspace_app_re.match(parts.path)
+        if app_match is None:
+            return None
+        app = app_match.group(1)
+        return ResolvedShareLink(
+            url=url,
+            provider="google_drive",
+            kind=ShareLinkKind.FILE,
+            reason=(
+                f"Google Workspace ({app}) documents are not stored as files: they "
+                "have to be exported, and the export format is a caller decision "
+                "(and some apps offer no export at all). graze refuses rather than "
+                "pick a format for you -- fetch the export endpoint yourself, or "
+                "use the Drive API."
+            ),
+        )
+
+    if host not in GOOGLE_DRIVE_HOSTS:
+        return None
+
+    if parts.path in _GDRIVE_DIRECT_PATHS.get(host, ()) and _query_value(
+        parts.query, "id"
+    ):
+        return ResolvedShareLink(
+            url=url,
+            provider="google_drive",
+            kind=ShareLinkKind.FILE,
+            direct_url=url,  # already a download endpoint; keep its parameters
+        )
+
+    folder_match = _gdrive_folder_path_re.match(parts.path)
+    if folder_match:
+        folder_id = folder_match.group(1)
+        return ResolvedShareLink(
+            url=url,
+            provider="google_drive",
+            kind=ShareLinkKind.FOLDER,
+            reason=(
+                "Google Drive folder links have no direct-download URL: enumerating "
+                "a folder needs the Drive API (files.list with "
+                f"q=\"'{folder_id}' in parents\") and a credential. graze refuses "
+                "rather than resolve a folder id as if it were a file id."
+            ),
+        )
+
+    file_match = _gdrive_file_path_re.match(parts.path)
+    file_id = file_match.group(1) if file_match else None
+    if file_id is None and parts.path == "/open":
+        file_id = _query_value(parts.query, "id")
+    if file_id is None:
+        return None
+
+    return ResolvedShareLink(
+        url=url,
+        provider="google_drive",
+        kind=ShareLinkKind.FILE,
+        direct_url=_google_drive_file_url(
+            file_id, resource_key=_query_value(parts.query, "resourcekey")
+        ),
+    )
+
+
+# --------------------------------------------------------------------------------------
+# OneDrive / SharePoint
+#
+# Recognised but NOT resolved, on purpose. graze has no *measured* contract for this
+# provider (unlike Dropbox above), and a share link fetched directly generally returns
+# an HTML page rather than the file -- so passing it through as an ordinary URL would
+# silently store a web page as if it were the asset. Refusing says so out loud.
+
+ONEDRIVE_HOSTS = ("1drv.ms", "onedrive.live.com")
+_SHAREPOINT_HOST_SUFFIX = ".sharepoint.com"
+
+#: `1drv.ms/f/...` and `<tenant>.sharepoint.com/:f:/...` are the folder markers.
+_onedrive_short_re = re.compile(r"^/(?P<marker>[a-zA-Z])/")
+_sharepoint_share_re = re.compile(r"^/:(?P<marker>[a-zA-Z]):/")
+_ONEDRIVE_FOLDER_MARKER = "f"
+
+ONEDRIVE_UNRESOLVED_REASON = (
+    "graze has no measured resolution rule for OneDrive/SharePoint share links, so "
+    "it refuses rather than guess -- fetching one directly generally returns an HTML "
+    "page, not the file. The candidate rule to measure (UNVERIFIED) is the anonymous "
+    "share endpoint https://api.onedrive.com/v1.0/shares/u!<b>/root/content, where "
+    "<b> is the base64url encoding of the share URL with '=' padding stripped. "
+    "Measure it against a live link, then register an adapter with "
+    "add_share_link_resolver."
+)
+
+
+def resolve_onedrive(url: str) -> Optional[ResolvedShareLink]:
+    """Recognise a OneDrive / SharePoint share link, and refuse it.
+
+    >>> r = resolve_onedrive('https://1drv.ms/f/s!AbCd')
+    >>> r.provider, r.kind.value, r.direct_url is None
+    ('onedrive', 'folder', True)
+
+    >>> r = resolve_onedrive('https://contoso-my.sharepoint.com/:v:/g/personal/x/EaB')
+    >>> r.provider, r.kind.value
+    ('onedrive', 'unknown')
+
+    An ordinary SharePoint document path is not a share link:
+
+    >>> resolve_onedrive('https://contoso.sharepoint.com/sites/x/clip.mp4') is None
+    True
+    """
+    host = _host_of(url)
+    path = urlsplit(url).path
+    if host in ONEDRIVE_HOSTS:
+        match = _onedrive_short_re.match(path) if host == "1drv.ms" else None
+    elif host.endswith(_SHAREPOINT_HOST_SUFFIX):
+        match = _sharepoint_share_re.match(path)
+        if match is None:
+            return None
+    else:
+        return None
+    marker = match.group("marker").lower() if match else None
+    kind = (
+        ShareLinkKind.FOLDER
+        if marker == _ONEDRIVE_FOLDER_MARKER
+        else ShareLinkKind.UNKNOWN
+    )
+    return ResolvedShareLink(
+        url=url,
+        provider="onedrive",
+        kind=kind,
+        reason=ONEDRIVE_UNRESOLVED_REASON,
+    )
+
+
+# --------------------------------------------------------------------------------------
+# The registry
+
+
+#: Provider adapters, tried in order; the first non-``None`` result wins. Open-closed:
+#: extend it with :func:`add_share_link_resolver` instead of editing this module.
+share_link_resolvers: dict[str, ShareLinkResolver] = {
+    "dropbox": resolve_dropbox,
+    "google_drive": resolve_google_drive,
+    "onedrive": resolve_onedrive,
+}
+
+
+def add_share_link_resolver(provider: str, resolver: ShareLinkResolver) -> None:
+    """Register (or replace) a provider adapter.
+
+    ``resolver`` takes a URL and returns a :class:`ResolvedShareLink`, or ``None``
+    to mean "not mine, try the next one". Replacing an existing provider keeps its
+    position in the try-order; a new one is appended (so it is tried last).
+    """
+    share_link_resolvers[provider] = resolver
+
+
+#: Schemes a plain URL may pass through with. Anything else is refused: this module
+#: describes *fetchable web resources*, and unknown schemes are not that.
+PASSTHROUGH_SCHEMES = ("http", "https")
+
+
+def _resolve_plain_url(url: str) -> ResolvedShareLink:
+    """Fallback for a URL that is nobody's share link: pass it through.
+
+    ``kind`` is ``FILE`` in the sense of "one blob" -- whether that blob turns out
+    to be a ZIP is a property of the *response*, which only the transport layer
+    can see. Guessing it from a file extension here would be exactly the kind of
+    silent mis-resolution this module exists to remove.
+
+    >>> _resolve_plain_url('https://example.com/a.mp4').direct_url
+    'https://example.com/a.mp4'
+    >>> _resolve_plain_url('not a url').provider
+    'unknown'
+    """
+    parts = urlsplit(url)
+    if parts.scheme.lower() in PASSTHROUGH_SCHEMES and parts.netloc:
+        return ResolvedShareLink(
+            url=url, provider="http", kind=ShareLinkKind.FILE, direct_url=url
+        )
+    return ResolvedShareLink(
+        url=url,
+        provider="unknown",
+        kind=ShareLinkKind.UNKNOWN,
+        reason=(
+            "Not an http(s) URL with a host, so there is nothing to fetch "
+            f"(scheme={parts.scheme!r})."
+        ),
+    )
+
+
+def resolve_share_url(
+    url: str, *, resolvers: Optional[dict[str, ShareLinkResolver]] = None
+) -> ResolvedShareLink:
+    """Describe what a share URL denotes and how (or whether) to fetch it.
+
+    Args:
+        url: The URL as a user pasted it. Surrounding whitespace is stripped.
+        resolvers: Adapters to try, in order. Defaults to
+            :data:`share_link_resolvers`; pass your own to test in isolation.
+
+    Returns:
+        A :class:`ResolvedShareLink`. Never raises for an unresolvable link --
+        the refusal is in the return value (``direct_url is None`` plus a
+        ``reason``). Use :func:`direct_download_url` when you want the raise.
+
+    >>> resolve_share_url('  https://www.dropbox.com/s/a1/x.csv?dl=0  ').direct_url
+    'https://www.dropbox.com/s/a1/x.csv?dl=1'
+    >>> resolve_share_url('https://example.com/a.mp4').provider
+    'http'
+    >>> resolve_share_url('ftp://example.com/a.mp4').resolved
+    False
+    """
+    if resolvers is None:
+        resolvers = share_link_resolvers
+    url = url.strip()
+    for resolve in resolvers.values():
+        resolved = resolve(url)
+        if resolved is not None:
+            return resolved
+    return _resolve_plain_url(url)
+
+
+def direct_download_url(
+    url: str, *, resolvers: Optional[dict[str, ShareLinkResolver]] = None
+) -> str:
+    """The URL to actually fetch, or raise :class:`ShareLinkResolutionError`.
+
+    >>> direct_download_url('https://drive.google.com/file/d/1AbC/view')
+    'https://drive.google.com/uc?export=download&id=1AbC'
+    >>> direct_download_url('https://1drv.ms/u/s!AbCd')
+    Traceback (most recent call last):
+        ...
+    graze.share_links.ShareLinkResolutionError: Cannot resolve this onedrive link...
+    """
+    resolved = resolve_share_url(url, resolvers=resolvers)
+    if resolved.direct_url is None:
+        raise ShareLinkResolutionError(
+            f"Cannot resolve this {resolved.provider} link to a direct-download URL "
+            f"({resolved.url}). {resolved.reason}"
+        )
+    return resolved.direct_url

--- a/graze/share_links.py
+++ b/graze/share_links.py
@@ -304,11 +304,16 @@ _gdrive_file_path_re = re.compile(r"^/file/d/([\w-]+)")
 _gdrive_folder_path_re = re.compile(r"^/drive/(?:u/\d+/)?folders/([\w-]+)")
 _gworkspace_app_re = re.compile(r"^/(document|spreadsheets|presentation|forms)/d/")
 
+#: A Workspace path that already names an export / publish endpoint (`/export`,
+#: `/export/pdf`, `/pub`, `/pubhtml`, `/gviz/tq`) is a *direct* URL: the caller has
+#: already made the format choice this module otherwise refuses to make for them.
+_gworkspace_direct_re = re.compile(r"/(?:export|pub[a-z]*|gviz)(?:/|$)")
+
 #: Paths that are already direct-download endpoints -- pass them through untouched
 #: rather than rebuild them, so any extra parameters they carry survive.
-_GDRIVE_DIRECT_PATHS = {
-    "drive.google.com": ("/uc",),
-    "drive.usercontent.google.com": ("/download",),
+_GDRIVE_DIRECT_PATH_RES = {
+    "drive.google.com": re.compile(r"^/(?:u/\d+/)?uc$"),
+    "drive.usercontent.google.com": re.compile(r"^/download$"),
 }
 
 
@@ -356,6 +361,13 @@ def resolve_google_drive(url: str) -> Optional[ResolvedShareLink]:
     >>> r.kind.value, r.direct_url is None
     ('file', True)
 
+    ...*unless* the caller already chose a format, which is the only thing the
+    refusal above was ever about:
+
+    >>> u = 'https://docs.google.com/spreadsheets/d/1Sh/export?format=csv&gid=0'
+    >>> resolve_google_drive(u).direct_url == u
+    True
+
     >>> resolve_google_drive('https://example.com/file/d/1AbC/view') is None
     True
     """
@@ -366,6 +378,15 @@ def resolve_google_drive(url: str) -> Optional[ResolvedShareLink]:
         app_match = _gworkspace_app_re.match(parts.path)
         if app_match is None:
             return None
+        if _gworkspace_direct_re.search(parts.path):
+            # The caller already picked a format -- that is the whole decision this
+            # adapter declines to make, so there is nothing left to refuse.
+            return ResolvedShareLink(
+                url=url,
+                provider="google_drive",
+                kind=ShareLinkKind.FILE,
+                direct_url=url,
+            )
         app = app_match.group(1)
         return ResolvedShareLink(
             url=url,
@@ -375,15 +396,17 @@ def resolve_google_drive(url: str) -> Optional[ResolvedShareLink]:
                 f"Google Workspace ({app}) documents are not stored as files: they "
                 "have to be exported, and the export format is a caller decision "
                 "(and some apps offer no export at all). graze refuses rather than "
-                "pick a format for you -- fetch the export endpoint yourself, or "
-                "use the Drive API."
+                "pick a format for you. Pass the export endpoint itself -- e.g. "
+                ".../export?format=<fmt>, .../pub?output=<fmt>, .../gviz/tq?... -- "
+                "and graze will fetch it as given."
             ),
         )
 
     if host not in GOOGLE_DRIVE_HOSTS:
         return None
 
-    if parts.path in _GDRIVE_DIRECT_PATHS.get(host, ()) and _query_value(
+    # Total: every host in GOOGLE_DRIVE_HOSTS is a key, and we returned above otherwise.
+    if _GDRIVE_DIRECT_PATH_RES[host].match(parts.path) and _query_value(
         parts.query, "id"
     ):
         return ResolvedShareLink(

--- a/graze/util.py
+++ b/graze/util.py
@@ -8,6 +8,12 @@ import urllib
 import re
 from io import BytesIO
 
+from graze.share_links import (
+    ShareLinkResolutionError,
+    direct_download_url,
+    resolve_share_url,
+)
+
 Filepath = str
 
 
@@ -296,92 +302,90 @@ def download_url_contents(
 bytes_of_url_content = partial(download_url_contents, file=None)
 
 
+# --------------------- Share links ---------------------
+#
+# Recognising a share link and turning it into a direct-download URL is a *pure*
+# concern -- no sockets, no redirects, no byte caps -- so it lives in its own module,
+# `graze.share_links`, where it is testable offline. Everything below is the thin
+# I/O half: resolve first, then download whatever the resolution points at.
+
+
+def is_share_url_of(provider: str) -> Callable[[str], bool]:
+    """Make a predicate: "is this URL a share link of `provider`?".
+
+    >>> is_dropbox = is_share_url_of('dropbox')
+    >>> is_dropbox('https://www.dropbox.com/scl/fo/q7/z?rlkey=abc&dl=0')
+    True
+    >>> is_dropbox('https://example.com/data.csv')
+    False
+    """
+
+    def _is_provider_url(url: str) -> bool:
+        return resolve_share_url(url).provider == provider
+
+    _is_provider_url.__name__ = f"is_{provider}_url"
+    _is_provider_url.__qualname__ = _is_provider_url.__name__
+    _is_provider_url.__doc__ = f"Whether `url` is a {provider} share link."
+    return _is_provider_url
+
+
+def download_from_share_link(
+    url: str, file=None, *, chk_size=DFLT_CHK_SIZE, user_agent=DFLT_USER_AGENT
+):
+    """Resolve a share link to its direct-download URL, then download that.
+
+    Raises `ShareLinkResolutionError` (a `ValueError`) when the link cannot be
+    resolved without a provider API -- deliberately, in preference to fetching the
+    share URL itself and silently storing an HTML preview page as if it were the
+    asset.
+
+    Note that what comes back may be an *archive*: a Dropbox folder link downloads
+    as a single ZIP holding every member. Check
+    `resolve_share_url(url).kind == ShareLinkKind.ARCHIVE` and expand it (e.g. with
+    `dol.FilesOfZip`) rather than treating those bytes as one asset.
+    """
+    return download_url_contents(
+        direct_download_url(url), file, chk_size=chk_size, user_agent=user_agent
+    )
+
+
 # --------------------- Dropbox ---------------------
 
-# Note to the developper: In Dropbox shared links, the query parameter dl controls how
-# the link behaves:
-# * dl=0: The link opens a preview page for the file on the Dropbox website.
-#   It's used when you want to share a viewable link rather than a direct download link.
-# * dl=1: The link becomes a direct download link. When someone clicks on this link,
-#   the file starts downloading immediately, instead of opening a preview page.
-# Changing the value of dl in a Dropbox link is a common way to control the user
-# experience when accessing shared files.
+# Note to the developer: in Dropbox share links, the query parameter `dl` controls what
+# the link serves:
+# * dl=0: intended as a preview page -- but what you get is User-Agent dependent
+#   (measured: a wget UA got the archive, a browser UA got 224 KB of HTML).
+# * dl=1: a direct download, deterministic across clients.
+# Which is why `graze.share_links.resolve_dropbox` forces dl=1 -- correctness, not
+# convenience. Note also that a *folder* link downloads as a ZIP, even when the folder
+# holds a single file.
 
-drobox_url_re = re.compile(r"https?://www\.dropbox\.com/s/.+\?dl=(0|1)$")
-
-
-def is_dropbox_url(url: str):
-    return bool(drobox_url_re.match(url))
-
-
-download_from_dropbox = download_url_contents  # backwards compatibility alias
-bytes_from_dropbox = bytes_of_url_content  # backwards compatibility alias
+is_dropbox_url = is_share_url_of("dropbox")
 
 # --------------------- Google Drive ---------------------
 
-_google_drive_file_id_patterns = (
-    r"drive\.google\.com/file/d/([\w-]+)",  # Standard file URL
-    r"drive\.google\.com/uc\?export=download&id=([\w-]+)",  # Direct download link
-    r"drive\.google\.com/open\?id=([\w-]+)",  # Open link format
-    r"docs\.google\.com/spreadsheets/d/([\w-]+)",  # Google Sheets URL
-    r"docs\.google\.com/document/d/([\w-]+)",  # Google Docs URL
-    r"docs\.google\.com/presentation/d/([\w-]+)",  # Google Slides URL
-    r"docs\.google\.com/forms/d/([\w-]+)",  # Google Forms URL
-    r"drive\.google\.com/drive/folders/([\w-]+)",  # Google Drive folder URL
-    r"drive\.google\.com/drive/u/\d/folders/([\w-]+)",  # Google Drive folder with user ID
-    r"drive\.google\.com/file/d/([\w-]+)",  # Standard file link with variations
-    r"drive\.google\.com/file/d/([\w-]+)/view",  # File view URL
-    r"drive\.google\.com/file/d/([\w-]+)/edit",  # File edit URL
-    r"drive\.google\.com/file/d/([\w-]+)/preview",  # File preview URL
-)
-_google_drive_file_id_pattern = re.compile("|".join(_google_drive_file_id_patterns))
-
-
-def _google_drive_id(url: str) -> str:
-    match = _google_drive_file_id_pattern.search(url)
-    if match:
-        # Return the first non-None group found in the match
-        return next(g for g in match.groups() if g is not None)
-    else:
-        msg = "Only FILE Google Drive URLs are supported, "
-        msg += "which have the format '...drive.google.com/file/d/{file_id}... "
-        msg += f"This url is not supported: {url}"
-        raise ValueError(msg)
-
-
-def is_google_drive_url(url: str) -> bool:
-    """
-    Checks if the provided URL is a Google Drive URL.
-
-    Args:
-        url (str): The URL to check.
-
-    Returns:
-        bool: True if the URL is a Google Drive URL, False otherwise.
-
-    >>> is_google_drive_url('https://drive.google.com/file/d/1Ul5mPePKAO11dG98GN/view')
-    True
-    >>> is_google_drive_url('http://drive.google.com/file/d/1Ul5mPePKAO11dG98GN/view')
-    True
-    >>> is_google_drive_url('https://example.com/file/d/1Ul5mPePKAO11dG98GN/view')
-    False
-    """
-    try:
-        _google_drive_id(url)
-        return True
-    except ValueError:
-        return False
+is_google_drive_url = is_share_url_of("google_drive")
 
 
 def google_drive_download_url(url):
-    """Get the download url from a FILE Google Drive URL.
+    """Get the direct-download url of a Google Drive FILE url.
 
-    Note: File URLs have the format: `...drive.google.com/file/d/{file_id}...`.
-    Folder URLs as well as "special format" (google docs, sheets, etc.) URLs are not
-    supported.
+    Raises `ShareLinkResolutionError` for a *folder* URL (enumerating one needs the
+    Drive API) and for a Google Workspace document (those must be exported, and the
+    format is a caller decision) -- rather than build a file-download URL out of a
+    folder id, which is what graze used to do.
+
+    >>> google_drive_download_url('https://drive.google.com/file/d/1Ab/view')
+    'https://drive.google.com/uc?export=download&id=1Ab'
     """
-    file_id = _google_drive_id(url)
-    return f"https://drive.google.com/uc?export=download&id={file_id}"
+    resolved = resolve_share_url(url)
+    if resolved.provider != "google_drive":
+        raise ValueError(f"Not a Google Drive url: {url}")
+    if resolved.direct_url is None:
+        raise ShareLinkResolutionError(
+            f"Cannot resolve this Google Drive url ({url}). {resolved.reason}"
+        )
+    return resolved.direct_url
 
 
 def _is_html_doc(src: bytes | Filepath):
@@ -405,9 +409,11 @@ def download_from_google_drive(
     or file-like object.
     If `file=None`, returns the bytes of the contents of the url.
 
-    Note: File URLs have the format: `...drive.google.com/file/d/{file_id}...`.
-    Folder URLs as well as "special format" (google docs, sheets, etc.) URLs are not
-    supported.
+    Only FILE urls (`...drive.google.com/file/d/{file_id}...`, `/open?id=`, and the
+    already-direct `/uc?...id=` and `drive.usercontent.google.com/download?id=` forms)
+    can be downloaded. A *folder* url, or a Google Workspace document (docs, sheets,
+    slides, forms), raises `ShareLinkResolutionError` -- see
+    `google_drive_download_url`.
     """
     _download_kwargs = dict(chk_size=chk_size, user_agent=user_agent)
     download_url = google_drive_download_url(url)
@@ -440,12 +446,25 @@ def url_with_virus_scan_confirmation_token(url, page_html):
     return url + "&confirm=" + confirmation_token
 
 
+# --------------------- OneDrive ---------------------
+
+is_onedrive_url = is_share_url_of("onedrive")
+
+
 # --------------------- Special URLS ---------------------
 
-# Note: Add/edit default special url routes here:
+# Note: Add/edit default special url routes here.
+# The predicates come from the `graze.share_links` registry -- that module is the single
+# place a provider is described, so adding one there is enough to recognise it here.
+# `download_from_share_link` covers every provider whose resolution is "rewrite the URL,
+# then GET it"; providers needing more (Google Drive's virus-scan interstitial) get their
+# own downloader. OneDrive is routed on purpose even though graze cannot resolve it: the
+# route raises a message saying so, where falling through to a plain GET would silently
+# store a login page as if it were the asset.
 special_url_routes = {
-    is_dropbox_url: download_url_contents,
+    is_dropbox_url: download_from_share_link,
     is_google_drive_url: download_from_google_drive,
+    is_onedrive_url: download_from_share_link,
 }
 
 

--- a/tests/test_share_links.py
+++ b/tests/test_share_links.py
@@ -138,14 +138,27 @@ def test_google_drive_file_links_resolve_to_the_download_endpoint(url):
     "url",
     [
         "https://drive.google.com/uc?export=download&id=1AbC",
+        "https://drive.google.com/uc?id=1AbC&export=download",  # params in either order
+        "https://drive.google.com/u/0/uc?id=1AbC&export=download",
         "https://drive.usercontent.google.com/download?id=1AbC&export=download",
+        # Workspace endpoints where the caller has ALREADY chosen the format -- which
+        # is the only decision the Workspace refusal is about, so there is nothing
+        # left to refuse. Refusing these would break `graze`ing a published sheet.
+        "https://docs.google.com/spreadsheets/d/1Sh/export?format=csv&gid=0",
+        "https://docs.google.com/spreadsheets/d/1Sh/gviz/tq?tqx=out:csv",
+        "https://docs.google.com/spreadsheets/d/e/2PACX-1v/pub?output=csv",
+        "https://docs.google.com/spreadsheets/d/e/2PACX-1v/pubhtml",
+        "https://docs.google.com/document/d/1Do/export?format=pdf",
+        "https://docs.google.com/presentation/d/1Pr/export/pdf",
     ],
 )
-def test_already_direct_google_drive_urls_pass_through_untouched(url):
+def test_already_direct_google_urls_pass_through_untouched(url):
     """Rebuilding them would drop whatever extra parameters they carry."""
     resolved = resolve_share_url(url)
     assert resolved.provider == "google_drive"
+    assert resolved.kind is ShareLinkKind.FILE
     assert resolved.direct_url == url
+    assert direct_download_url(url) == url
 
 
 def test_google_drive_resourcekey_is_preserved():

--- a/tests/test_share_links.py
+++ b/tests/test_share_links.py
@@ -1,0 +1,435 @@
+"""Offline tests for share-link resolution (`graze.share_links`).
+
+Every test here is pure string -> string. Nothing in this file opens a socket --
+that is the entire reason resolution is a separate layer from transport, so a test
+that needed the network would be evidence of a design regression, not a flaky test.
+"""
+
+import doctest
+
+import pytest
+
+import graze.util as util
+from graze.share_links import (
+    ResolvedShareLink,
+    ShareLinkKind,
+    ShareLinkResolutionError,
+    add_share_link_resolver,
+    direct_download_url,
+    resolve_share_url,
+    share_link_resolvers,
+)
+
+
+# --------------------------------------------------------------------------------------
+# Dropbox
+#
+# Regression guard for the `/s/`-only regex: `is_dropbox_url` used to be
+# `https?://www\.dropbox\.com/s/.+\?dl=(0|1)$`, which is False for every modern
+# (`/scl/`) share link, for any link with a trailing parameter, and for any link
+# copied without `?dl=`.
+
+
+@pytest.mark.parametrize(
+    "url,kind",
+    [
+        # modern forms -- the whole family the old regex missed
+        (
+            "https://www.dropbox.com/scl/fi/a1b2/clip.mp4?rlkey=zz&st=q9&dl=0",
+            ShareLinkKind.FILE,
+        ),
+        (
+            "https://www.dropbox.com/scl/fo/q7x/AAB?rlkey=zz&st=q9&dl=0",
+            ShareLinkKind.ARCHIVE,
+        ),
+        # legacy forms
+        ("https://www.dropbox.com/s/a1b2/data.csv?dl=0", ShareLinkKind.FILE),
+        ("https://www.dropbox.com/sh/a1b2/AAAhash?dl=0", ShareLinkKind.ARCHIVE),
+        # no `dl` param at all
+        ("https://www.dropbox.com/scl/fi/a1b2/clip.mp4?rlkey=zz", ShareLinkKind.FILE),
+        ("https://www.dropbox.com/s/a1b2/data.csv", ShareLinkKind.FILE),
+        # trailing params after `dl`, and `dl` already correct
+        (
+            "https://www.dropbox.com/s/a1b2/data.csv?dl=1&st=q9",
+            ShareLinkKind.FILE,
+        ),
+        # http, and the host without `www.`
+        ("http://www.dropbox.com/s/a1b2/data.csv?dl=0", ShareLinkKind.FILE),
+        ("https://dropbox.com/scl/fi/a1b2/clip.mp4?rlkey=zz", ShareLinkKind.FILE),
+    ],
+)
+def test_dropbox_links_are_recognised_and_forced_to_dl_1(url, kind):
+    resolved = resolve_share_url(url)
+    assert resolved.provider == "dropbox"
+    assert resolved.kind is kind
+    assert util.is_dropbox_url(url) is True
+    # `dl=1` is a correctness requirement: `dl=0` serves the archive or an HTML page
+    # depending on the User-Agent.
+    assert resolved.direct_url.endswith("dl=1")
+    assert "dl=0" not in resolved.direct_url
+
+
+def test_dropbox_folder_link_is_an_archive_not_a_file():
+    """A folder link downloads as one ZIP of N members -- a different operation."""
+    file_link = resolve_share_url("https://www.dropbox.com/scl/fi/a1/x.mp4?rlkey=z")
+    folder_link = resolve_share_url("https://www.dropbox.com/scl/fo/a1/x?rlkey=z")
+    assert file_link.kind is ShareLinkKind.FILE
+    assert folder_link.kind is ShareLinkKind.ARCHIVE
+    assert file_link.kind is not folder_link.kind
+
+
+def test_dropbox_rewrite_preserves_every_other_parameter_verbatim():
+    """`rlkey` is a bearer secret: corrupting it makes the link a 404."""
+    url = "https://www.dropbox.com/scl/fo/q7x/AAB?rlkey=aB-_9~x&st=q9&dl=0#frag"
+    direct = resolve_share_url(url).direct_url
+    assert (
+        direct == "https://www.dropbox.com/scl/fo/q7x/AAB?rlkey=aB-_9~x&st=q9&dl=1#frag"
+    )
+
+
+def test_dropbox_duplicate_dl_params_collapse_to_one():
+    url = "https://www.dropbox.com/s/a1/x.csv?dl=0&st=q&dl=0"
+    assert resolve_share_url(url).direct_url == (
+        "https://www.dropbox.com/s/a1/x.csv?st=q&dl=1"
+    )
+
+
+def test_non_share_dropbox_urls_fall_through_to_passthrough():
+    """A Dropbox web page is not a share link; don't claim it."""
+    resolved = resolve_share_url("https://www.dropbox.com/home")
+    assert resolved.provider == "http"
+    assert util.is_dropbox_url("https://www.dropbox.com/home") is False
+
+
+def test_unknown_dropbox_scl_subtype_is_refused_not_guessed():
+    resolved = resolve_share_url("https://www.dropbox.com/scl/zz/a1/x?rlkey=z")
+    assert resolved.provider == "dropbox"
+    assert resolved.kind is ShareLinkKind.UNKNOWN
+    assert resolved.direct_url is None
+    assert "add_share_link_resolver" in resolved.reason
+
+
+# --------------------------------------------------------------------------------------
+# Google Drive
+#
+# Regression guard for the folder branch: `google_drive_download_url` used to build
+# a *file* download URL out of a *folder* id.
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://drive.google.com/file/d/1AbC/view",
+        "https://drive.google.com/file/d/1AbC/edit",
+        "https://drive.google.com/file/d/1AbC/preview",
+        "https://drive.google.com/file/d/1AbC",
+        "https://drive.google.com/file/d/1AbC/view?usp=sharing",
+        "https://drive.google.com/open?id=1AbC",
+    ],
+)
+def test_google_drive_file_links_resolve_to_the_download_endpoint(url):
+    resolved = resolve_share_url(url)
+    assert resolved.provider == "google_drive"
+    assert resolved.kind is ShareLinkKind.FILE
+    assert resolved.direct_url == "https://drive.google.com/uc?export=download&id=1AbC"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://drive.google.com/uc?export=download&id=1AbC",
+        "https://drive.usercontent.google.com/download?id=1AbC&export=download",
+    ],
+)
+def test_already_direct_google_drive_urls_pass_through_untouched(url):
+    """Rebuilding them would drop whatever extra parameters they carry."""
+    resolved = resolve_share_url(url)
+    assert resolved.provider == "google_drive"
+    assert resolved.direct_url == url
+
+
+def test_google_drive_resourcekey_is_preserved():
+    """Link-shared files created before Drive's 2021 change need it to be readable."""
+    url = "https://drive.google.com/file/d/1AbC/view?usp=sharing&resourcekey=0-xY_z"
+    assert resolve_share_url(url).direct_url == (
+        "https://drive.google.com/uc?export=download&id=1AbC&resourcekey=0-xY_z"
+    )
+
+
+@pytest.mark.parametrize(
+    "url,folder_id",
+    [
+        ("https://drive.google.com/drive/folders/1FoLdEr", "1FoLdEr"),
+        ("https://drive.google.com/drive/u/0/folders/1FoLdEr", "1FoLdEr"),
+        ("https://drive.google.com/drive/u/12/folders/1FoLdEr", "1FoLdEr"),
+    ],
+)
+def test_google_drive_folder_is_refused_never_resolved_as_a_file(url, folder_id):
+    resolved = resolve_share_url(url)
+    assert resolved.provider == "google_drive"
+    assert resolved.kind is ShareLinkKind.FOLDER
+    # The precise defect being guarded: a folder id in a *file* download URL.
+    assert resolved.direct_url is None
+    assert resolved.direct_url != (
+        f"https://drive.google.com/uc?export=download&id={folder_id}"
+    )
+    assert "Drive API" in resolved.reason
+    with pytest.raises(ShareLinkResolutionError):
+        direct_download_url(url)
+    with pytest.raises(ShareLinkResolutionError):
+        util.google_drive_download_url(url)
+    # ...but it is still *recognised*, so the route fires and the caller gets the
+    # error instead of silently downloading Drive's HTML folder page.
+    assert util.is_google_drive_url(url) is True
+
+
+@pytest.mark.parametrize(
+    "url,app",
+    [
+        ("https://docs.google.com/document/d/1Do/edit", "document"),
+        ("https://docs.google.com/spreadsheets/d/1Sh/edit#gid=0", "spreadsheets"),
+        ("https://docs.google.com/presentation/d/1Pr/edit", "presentation"),
+        ("https://docs.google.com/forms/d/1Fo/viewform", "forms"),
+    ],
+)
+def test_google_workspace_docs_are_refused_not_mis_resolved(url, app):
+    resolved = resolve_share_url(url)
+    assert resolved.provider == "google_drive"
+    assert resolved.direct_url is None
+    assert app in resolved.reason
+    assert util.is_google_drive_url(url) is True
+
+
+def test_google_drive_download_url_rejects_a_non_drive_url():
+    with pytest.raises(ValueError):
+        util.google_drive_download_url("https://example.com/file.mp4")
+
+
+# --------------------------------------------------------------------------------------
+# Host spoofing
+#
+# Regression guard: `_google_drive_id` used to `.search()` the raw URL string, so any
+# URL merely *containing* "drive.google.com/file/d/<id>" was routed to Drive -- i.e.
+# graze fetched from a host the user never named.
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://evil.example.com/x?u=drive.google.com/file/d/1AbC",
+        "https://evil.example.com/drive.google.com/file/d/1AbC/view",
+        "https://drive.google.com.evil.example.com/file/d/1AbC/view",
+        "https://example.com/s/a1b2/data.csv?dl=0",
+        "https://www.dropbox.com.evil.example.com/scl/fi/a1/x?dl=0",
+    ],
+)
+def test_a_lookalike_host_is_never_treated_as_the_provider(url):
+    resolved = resolve_share_url(url)
+    assert resolved.provider == "http"
+    assert resolved.direct_url == url
+    assert util.is_google_drive_url(url) is False
+    assert util.is_dropbox_url(url) is False
+
+
+def test_host_matching_ignores_case_and_port():
+    resolved = resolve_share_url("https://Drive.Google.com:443/file/d/1AbC/view")
+    assert resolved.provider == "google_drive"
+
+
+# --------------------------------------------------------------------------------------
+# OneDrive -- recognised, and honestly refused
+
+
+@pytest.mark.parametrize(
+    "url,kind",
+    [
+        ("https://1drv.ms/f/s!AbCd", ShareLinkKind.FOLDER),
+        ("https://1drv.ms/u/s!AbCd", ShareLinkKind.UNKNOWN),
+        ("https://1drv.ms/v/s!AbCd", ShareLinkKind.UNKNOWN),
+        (
+            "https://contoso-my.sharepoint.com/:f:/g/personal/a/EaB",
+            ShareLinkKind.FOLDER,
+        ),
+        (
+            "https://contoso-my.sharepoint.com/:v:/g/personal/a/EaB",
+            ShareLinkKind.UNKNOWN,
+        ),
+        ("https://onedrive.live.com/?id=root&cid=ABC", ShareLinkKind.UNKNOWN),
+    ],
+)
+def test_onedrive_links_are_recognised_and_refused(url, kind):
+    resolved = resolve_share_url(url)
+    assert resolved.provider == "onedrive"
+    assert resolved.kind is kind
+    assert resolved.direct_url is None
+    assert "UNVERIFIED" in resolved.reason
+    assert util.is_onedrive_url(url) is True
+
+
+def test_an_ordinary_sharepoint_path_is_not_a_share_link():
+    url = "https://contoso.sharepoint.com/sites/x/Shared%20Documents/clip.mp4"
+    assert resolve_share_url(url).provider == "http"
+
+
+# --------------------------------------------------------------------------------------
+# Plain URLs, and non-URLs
+
+
+def test_plain_https_url_passes_through():
+    url = "https://example.com/assets/video.mp4?token=abc"
+    resolved = resolve_share_url(url)
+    assert (resolved.provider, resolved.kind) == ("http", ShareLinkKind.FILE)
+    assert resolved.direct_url == url
+    assert direct_download_url(url) == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    ["ftp://example.com/a.mp4", "file:///etc/hosts", "not a url", "", "example.com/a"],
+)
+def test_non_http_inputs_are_refused_with_a_reason(url):
+    resolved = resolve_share_url(url)
+    assert resolved.provider == "unknown"
+    assert resolved.direct_url is None
+    assert resolved.reason
+    with pytest.raises(ShareLinkResolutionError):
+        direct_download_url(url)
+
+
+def test_surrounding_whitespace_is_stripped():
+    resolved = resolve_share_url("  https://www.dropbox.com/s/a1/x.csv?dl=0\n")
+    assert resolved.url == "https://www.dropbox.com/s/a1/x.csv?dl=0"
+    assert resolved.direct_url == "https://www.dropbox.com/s/a1/x.csv?dl=1"
+
+
+# --------------------------------------------------------------------------------------
+# The data model and the registry
+
+
+def test_an_unresolved_link_must_carry_a_reason():
+    """An adapter that refuses silently is a bug; the dataclass enforces it."""
+    with pytest.raises(ValueError, match="must carry a reason"):
+        ResolvedShareLink("https://x/y", "nope", ShareLinkKind.UNKNOWN)
+
+
+def test_resolved_property_tracks_direct_url():
+    assert ResolvedShareLink("u", "http", ShareLinkKind.FILE, "u").resolved is True
+    assert (
+        ResolvedShareLink("u", "p", ShareLinkKind.UNKNOWN, None, "why").resolved
+        is False
+    )
+
+
+def test_share_link_kind_str_equals_its_value():
+    """`str, Enum` formatting changed in 3.11; pin it so messages don't drift."""
+    assert str(ShareLinkKind.ARCHIVE) == "archive"
+    assert f"{ShareLinkKind.ARCHIVE}" == "archive"
+    assert ShareLinkKind.ARCHIVE == "archive"
+
+
+def test_resolvers_can_be_injected_without_touching_the_global_registry():
+    def only_mine(url):
+        if url.startswith("https://mine.example/"):
+            return ResolvedShareLink(
+                url=url,
+                provider="mine",
+                kind=ShareLinkKind.FILE,
+                direct_url=url + "?raw=1",
+            )
+
+    resolvers = {"mine": only_mine}
+    assert resolve_share_url(
+        "https://mine.example/x", resolvers=resolvers
+    ).provider == ("mine")
+    # Dropbox is not in the injected registry, so it falls through to pass-through.
+    assert (
+        resolve_share_url(
+            "https://www.dropbox.com/s/a1/x.csv?dl=0", resolvers=resolvers
+        ).provider
+        == "http"
+    )
+    assert "mine" not in share_link_resolvers
+
+
+def test_add_share_link_resolver_extends_the_default_registry():
+    def resolve_example(url):
+        if url.startswith("https://newhost.example/"):
+            return ResolvedShareLink(
+                url=url, provider="newhost", kind=ShareLinkKind.ARCHIVE, direct_url=url
+            )
+
+    add_share_link_resolver("newhost", resolve_example)
+    try:
+        resolved = resolve_share_url("https://newhost.example/bundle")
+        assert (resolved.provider, resolved.kind) == ("newhost", ShareLinkKind.ARCHIVE)
+        assert util.is_share_url_of("newhost")("https://newhost.example/bundle") is True
+    finally:
+        del share_link_resolvers["newhost"]
+
+
+def test_every_default_resolver_returns_none_for_a_foreign_url():
+    """ "Not mine" must be `None`, so the next adapter gets a turn."""
+    for provider, resolve in share_link_resolvers.items():
+        assert resolve("https://example.com/a.mp4") is None, provider
+
+
+# --------------------------------------------------------------------------------------
+# The transport-side routing that consumes the resolution
+
+
+def _no_network(*args, **kwargs):
+    raise AssertionError("a share-link test attempted a network download")
+
+
+def test_special_url_routes_resolve_before_downloading(monkeypatch):
+    seen = []
+    monkeypatch.setattr(
+        util, "download_url_contents", lambda url, file, **kw: seen.append(url)
+    )
+    util.download_from_special_url("https://www.dropbox.com/scl/fo/a1/x?rlkey=z&dl=0")
+    assert seen == ["https://www.dropbox.com/scl/fo/a1/x?rlkey=z&dl=1"]
+
+
+def test_an_unresolvable_route_raises_instead_of_fetching_the_share_page(monkeypatch):
+    """The failure mode being prevented: storing an HTML page as if it were the asset."""
+    monkeypatch.setattr(util, "download_url_contents", _no_network)
+    for url in (
+        "https://1drv.ms/f/s!AbCd",
+        "https://drive.google.com/drive/folders/1FoLdEr",
+        "https://docs.google.com/document/d/1Do/edit",
+    ):
+        assert util.is_special_url(url) is True
+        with pytest.raises(ShareLinkResolutionError):
+            util.download_from_special_url(url)
+
+
+def test_a_plain_url_is_not_routed_as_special():
+    """Pass-through is the fallback, not a registered route -- otherwise every URL
+    in the world would be a "special url" and `Internet` would reroute all of them."""
+    assert util.is_special_url("https://example.com/a.mp4") is False
+    assert util.is_special_url("https://raw.githubusercontent.com/a/b/c.py") is False
+
+
+# --------------------------------------------------------------------------------------
+# Doctests
+#
+# `testpaths = ["tests"]`, so CI's `--doctest-modules` never reaches `graze/`.
+# Run the module's doctests explicitly so its examples are actually gated.
+
+
+def test_share_links_doctests():
+    import graze.share_links
+
+    results = doctest.testmod(
+        graze.share_links,
+        optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE,
+    )
+    assert results.failed == 0, f"{results.failed} doctest failure(s)"
+
+
+def test_util_share_link_doctests():
+    results = doctest.testmod(
+        util,
+        optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE,
+    )
+    assert results.failed == 0, f"{results.failed} doctest failure(s)"


### PR DESCRIPTION
Closes #6.

A *share link* is what a person copies out of Dropbox / Google Drive / OneDrive. It is **not** a download URL, and graze's handling of that fact was wrong in three separate ways. This adds `graze.share_links` — a **network-free** layer mapping a pasted URL to what it actually denotes — and rewires `graze.util` onto it.

```
share link  ->  ResolvedShareLink(provider, kind, direct_url, reason)
```

## The three defects, each verified before and after

All three are the same confusion: **recognising a link by string-matching instead of parsing it.**

**1. The Dropbox predicate missed every modern share link.** It was `https?://www\.dropbox\.com/s/.+\?dl=(0|1)$` — legacy `/s/` only, `?dl=` required, `$`-anchored. Measured on `master`:

| url | `is_dropbox_url` before | after |
|---|---|---|
| `…/s/abc/file.csv?dl=0` | `True` | `True` |
| `…/scl/fi/xyz/holiday.parquet?rlkey=k&st=t&dl=1` | **`False`** | `True` |
| `…/scl/fo/xyz/AAAA?rlkey=k&st=t&dl=1` | **`False`** | `True` |
| `…/s/abc/file.csv?dl=0&st=xyz` | **`False`** | `True` |
| `…/s/abc/file.csv` (no `dl`) | **`False`** | `True` |

…and the `dl=0` → `dl=1` rewrite it was meant to trigger existed **only in docstrings** (`base.py:527,543`) — nowhere in code. That rewrite is a **correctness** requirement, not a nicety: `dl=0` serves the archive *or* an HTML page **depending on the User-Agent**, while `dl=1` is deterministic across clients (#6 §3). It is now real code, and preserves every other query byte verbatim — `rlkey` is a bearer secret and re-encoding it is a needless way to break a link.

**2. Google Drive claimed folder support, then treated folders as files.** Before:

```
is_google_drive_url('…/drive/folders/1AbCdEfGhIjKlMnOp')   -> True
google_drive_download_url('…/drive/folders/1AbCdEfGhIjKlMnOp')
  -> 'https://drive.google.com/uc?export=download&id=1AbCdEfGhIjKlMnOp'   # a FILE url built from a FOLDER id
```

Same for Docs / Sheets / Slides / Forms. Now a folder resolves as `kind=FOLDER` with `direct_url=None` and a reason naming what it would actually take (`files.list` + a credential); a Workspace document is refused because its export format is a caller decision. Both stay **recognised**, so the route still fires and the caller gets the error — rather than falling through to a plain GET that stores Drive's HTML folder page as if it were the asset.

**3. Host spoofing (found while doing the above, not previously filed).** `_google_drive_id` ran `.search()` over the raw URL, so any URL merely *containing* the substring was routed to Drive:

```
is_google_drive_url('https://evil.example.com/x?u=drive.google.com/file/d/1AbCdEfGhIjK')
  -> True
google_drive_download_url(…) -> 'https://drive.google.com/uc?export=download&id=1AbCdEfGhIjK'
```

graze fetched from a host the user never named. Matching is now on the parsed hostname, which also rejects suffix lookalikes (`drive.google.com.evil.example.com`).

## What it returns, and where it refuses

`kind` is the second thing a caller needs, because **a folder link is an archive, not a listing** — Dropbox answers one with a ZIP even when the folder holds a single file (`README.md` already documented this in prose; it's now a supported return value, #6 §4).

| kind | meaning |
|---|---|
| `FILE` | one blob; the bytes are the asset |
| `ARCHIVE` | one blob that is a ZIP of N members — expand it (`dol.FilesOfZip`) |
| `FOLDER` | denotes a folder with **no** direct-download URL; needs a provider API |
| `UNKNOWN` | provider recognised, kind not determinable from the URL alone |

Coverage: Dropbox `/scl/fi/` `/scl/fo/` `/s/` `/sh/` · Drive `/file/d/`, `/open?id=`, the already-direct `/uc?id=` and `drive.usercontent…/download?id=` forms (passed through untouched so their parameters survive), plus `resourcekey` preservation for pre-2021 link-shared files · Drive folders + Workspace docs (**refused**) · OneDrive / SharePoint (**refused**) · plain HTTPS (pass-through) · non-http (refused).

**OneDrive is recognised and refused on purpose, and that is the honest answer.** #283 is explicit that its contract *"must be measured before an adapter is written, exactly as Dropbox's was here"* — and I have no link to measure against. So it is recognised (so it can't silently pass through and ingest a login page), refused with a reason, and the reason names the exact candidate rule to test, flagged `UNVERIFIED`. Writing a guessed adapter would have re-created defect #2 in a new provider. WeTransfer is left out for the same reason, and has no adapter at all.

Same discipline for Google Workspace: it would have been easy to emit `…/export?format=pdf`, but the format is a caller decision (a Sheet is equally csv/xlsx/pdf/ods) and the endpoint shape differs per app. Guessing one is exactly the class of bug this PR removes.

## Open-closed, one place per provider

`share_link_resolvers` is a `{provider: adapter}` registry; an adapter returns `None` for "not mine". `special_url_routes` **derives** its predicates from it, so a provider is described in exactly one place, and `add_special_url_route` still works for anyone who wants a bespoke downloader. Pass-through is deliberately the *fallback*, not a registered route — registering it would make every URL in the world a "special url" and reroute all of `Internet`'s traffic.

## Tests: 71, offline, deterministic

Pure string → string; the suite runs in 0.08 s and opens no socket. That is the *reason* this layer is separate from transport — a test here that needed the network would be evidence of a design regression.

`testpaths = ["tests"]`, so CI's `--doctest-modules` never reaches `graze/`; the module's doctests are gated explicitly by a `doctest.testmod` test instead.

### Mutation evidence

Every guard was verified by reintroducing its bug, **confirming the mutation actually landed on disk** (the helper re-reads the file, asserts disk == intended, and prints the mutated line), then confirming red → restoring → confirming green + byte-identical.

| # | mutation | result |
|---|---|---|
| 1 | restore the legacy `/s/`-only regex | **14 failed**, incl. all 4 modern/param-variant Dropbox cases |
| 2 | `direct_url=url` (drop the `dl=1` rewrite) | **14 failed** |
| 3 | `direct_url=_google_drive_file_url(folder_id)` (folder id as file id) | **5 failed**, incl. all 3 folder params |
| 4 | restore `.search()` over the raw URL | **5 failed**, incl. both embedded-substring spoofs |
| 5 | drop the Dropbox host check | **3 failed**, incl. the Dropbox-path-on-another-host spoof |

Mutation 4's first attempt is worth flagging: the helper *aborted* on an over-strict assertion while the write had already happened, so its pytest output was untrustworthy. I fixed the helper and redid it, printing the live mutant's actual resolutions (`google_drive <- https://evil.example.com/x?u=…`) as independent proof before trusting the red. Mutation 5 exists only because one spoof parametrisation stayed green under mutations 1–4 — a test no mutation can redden is decoration.

Verified on 3.10, 3.12 and 3.13 (the `str, Enum` `__format__` change in 3.11 is pinned by a test: `str(kind) == kind.value` on all three).

## ⚠ Breaking changes

- **Removed**: `drobox_url_re`, `_google_drive_id`, `_google_drive_file_id_pattern(s)`, `download_from_dropbox`, `bytes_from_dropbox`. The last two were labelled back-compat aliases to functions that did **not** normalise the URL — i.e. they were the bug. Use `download_from_share_link`.
- `google_drive_download_url` **raises** for folders and Workspace docs instead of returning a wrong URL.
- OneDrive / SharePoint links now **raise** `ShareLinkResolutionError` (a `ValueError`) instead of silently downloading a web page.

No consumer in the wider ecosystem imports any removed name (checked; the hits are each package's own private copy).

## Explicitly out of scope

- **Guarded transport** — redirect following + per-hop re-validation, byte caps, wall-clock deadlines, and the content-type / magic-byte assertion. That is the shared fetch substrate scoped by `thorwhalen/muvid#7`, and its SSRF guard is a prerequisite for it. Resolution stays pure precisely so that layer can be built, and tested, separately.
- **ZIP expansion** — `dol.FilesOfZip` already exists; `kind == ARCHIVE` is the signal to use it. Bounding member count and expanded bytes belongs with it.

Neither is built here. This PR is layer A of the three named in the downstream asset-ingest epic (`thorwhalen/reelee#283`, already referenced from #6).
